### PR TITLE
Fix publishing steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
   release:
     name: Publish Plugin
     runs-on: ubuntu-latest
+    environment: PublishEnvironment
     permissions:
       contents: write
       pull-requests: write

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,7 +149,10 @@ kover { reports { total { xml { onCheck = true } } } }
 tasks {
   wrapper { gradleVersion = providers.gradleProperty("gradleVersion").get() }
 
-  publishPlugin { dependsOn(patchChangelog) }
+  publishPlugin {
+    dependsOn(patchChangelog)
+    token = System.getenv("PUBLISH_TOKEN")
+  }
 
   test {
     useJUnitPlatform()


### PR DESCRIPTION
Fix publishing by making `publishPlugin` read from the environment variable, and then fix releasing by loading the right Github Actions environment.