### PR TITLE
Add documentOutline receipt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- Added ability to receive `tinymist/documentOutline` messages
 - Fixed bug with Jupyter server appearing as project filepath
 - Initial plugin and integration with Tinymist LSP created
   from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.github.garetht.typstsupport
 pluginName=typst-support
 pluginRepositoryUrl=https://github.com/garetht/typst-support
 # SemVer format -> https://semver.org
-pluginVersion=0.0.2
+pluginVersion=0.0.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=251

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TinymistLanguageServerDescriptor.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TinymistLanguageServerDescriptor.kt
@@ -32,7 +32,7 @@ class TinymistLanguageServerDescriptor(val languageServerPath: Path, project: Pr
   }
 
   override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient {
-    LOG.warn("Creating Tinymist language server client for project: ${project.name}")
+    LOG.info("Creating ${TypstLspClient::class.simpleName} language server client for project: ${project.name}")
     return TypstLspClient(project, handler)
   }
 

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TinymistLanguageServerDescriptor.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TinymistLanguageServerDescriptor.kt
@@ -9,7 +9,9 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.Lsp4jClient
 import com.intellij.platform.lsp.api.LspServerDescriptor
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.intellij.platform.lsp.api.customization.LspFormattingSupport
 import java.nio.file.Path
 
@@ -27,6 +29,11 @@ class TinymistLanguageServerDescriptor(val languageServerPath: Path, project: Pr
 
   init {
     LOG.info("Language server project base dirs: ${project.getBaseDirectories().map { it.path }}")
+  }
+
+  override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient {
+    LOG.warn("Creating Tinymist language server client for project: ${project.name}")
+    return TypstLspClient(project, handler)
   }
 
   val settings = SettingsState.getInstance()

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TypstLspClient.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TypstLspClient.kt
@@ -1,19 +1,16 @@
 package com.github.garetht.typstsupport.languageserver
 
 import com.github.garetht.typstsupport.languageserver.models.Outline
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.platform.lsp.api.Lsp4jClient
 import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 
-private val LOG = logger<TypstLspClient>()
 
 class TypstLspClient(
   project: Project,
   serverNotificationsHandler: LspServerNotificationsHandler,
 ) : Lsp4jClient(serverNotificationsHandler) {
   @JsonNotification("tinymist/documentOutline")
-  fun handleDocumentOutline(_: Outline) {
-  }
+  fun handleDocumentOutline(outline: Outline) = Unit
 }

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TypstLspClient.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/TypstLspClient.kt
@@ -1,0 +1,19 @@
+package com.github.garetht.typstsupport.languageserver
+
+import com.github.garetht.typstsupport.languageserver.models.Outline
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.Lsp4jClient
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
+
+private val LOG = logger<TypstLspClient>()
+
+class TypstLspClient(
+  project: Project,
+  serverNotificationsHandler: LspServerNotificationsHandler,
+) : Lsp4jClient(serverNotificationsHandler) {
+  @JsonNotification("tinymist/documentOutline")
+  fun handleDocumentOutline(_: Outline) {
+  }
+}

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/models/DocumentPosition.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/models/DocumentPosition.kt
@@ -1,0 +1,9 @@
+package com.github.garetht.typstsupport.languageserver.models
+
+import com.google.gson.annotations.SerializedName
+
+data class DocumentPosition(
+  @SerializedName("page_no") val pageNo: Int,
+  val x: Float,
+  val y: Float
+)

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/models/Outline.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/models/Outline.kt
@@ -1,0 +1,5 @@
+package com.github.garetht.typstsupport.languageserver.models
+
+data class Outline(
+  val items: List<OutlineItem>
+)

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/models/OutlineItem.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/models/OutlineItem.kt
@@ -1,0 +1,8 @@
+package com.github.garetht.typstsupport.languageserver.models
+
+data class OutlineItem(
+  val title: String,
+  val span: String? = null,
+  val position: DocumentPosition? = null,
+  val children: List<OutlineItem> = emptyList()
+)


### PR DESCRIPTION
Allows `tinymist/documentOutline` requests to be received.