### PR TITLE
Bump version of tinymist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- Upgraded Tinymist binary version to `v0.13.14`
 - Added ability to receive `tinymist/documentOutline` messages
 - Fixed bug with Jupyter server appearing as project filepath
 - Initial plugin and integration with Tinymist LSP created

--- a/README.md
+++ b/README.md
@@ -19,25 +19,25 @@
 
 ## Features
 
-#### Live side-by-side preview
+### Live side-by-side preview
 Changes to documents are updated in the preview window in real time.
 
-#### Reformat files
+### Reformat files
 Reformat entire files with `typstfmt` or `typstyle`.
 
-#### Documentation on Hover
+### Documentation on Hover
 Hover over a symbol to view its documentation.
 
-#### Jump to Definition from Preview
+### Jump to Definition from Preview
 Click on a part of the preview document to jump to the definition of that element in your Typst sources.
 
-#### Find Usages
+### Find Usages
 List all the places a symbol is used in the project.
 
-#### Autocomplete
+### Autocomplete
 Suggestions for symbols as you type.
 
-#### Bring your own binary
+### Bring your own binary
 Use a `tinymist` binary that exists on your system by pointing to its path locally.
 
 <!-- Plugin description end -->

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Suggestions for symbols as you type.
 ### Bring your own binary
 Use a `tinymist` binary that exists on your system by pointing to its path locally.
 
-<!-- Plugin description end -->
-
 # Feature Demos
 
 <h3>Live Preview</h3>
@@ -112,6 +110,8 @@ Specify your local version of `tinymist` to be used with this plugin.
 <p align="center">
   <img alt="Typst Support Logo" src="./assets/configuration.png" width="800" />
 </p>
+
+<!-- Plugin description end -->
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 ####
 
 <p align="center">
+
 [![Version](https://img.shields.io/jetbrains/plugin/v/27697-typst-support.svg)](https://plugins.jetbrains.com/plugin/27697-typst-support)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/27697-typst-support.svg)](https://plugins.jetbrains.com/plugin/27697-typst-support)
+
 </p>
 
 
@@ -17,21 +19,32 @@
 
 ## Features
 
-- Live Preview
-- Jump to Definition from Preview
-- Documentation on Hover
-- Find Usages
-- Autocomplete
-- Reformat files
-- Bring your own binary
-- ...and many more!
+#### Live side-by-side preview
+Changes to documents are updated in the preview window in real time.
+
+#### Reformat files
+Reformat entire files with `typstfmt` or `typstyle`.
+
+#### Documentation on Hover
+Hover over a symbol to view its documentation.
+
+#### Jump to Definition from Preview
+Click on a part of the preview document to jump to the definition of that element in your Typst sources.
+
+#### Find Usages
+List all the places a symbol is used in the project.
+
+#### Autocomplete
+Suggestions for symbols as you type.
+
+#### Bring your own binary
+Use a `tinymist` binary that exists on your system by pointing to its path locally.
 
 <!-- Plugin description end -->
 
 # Feature Demos
 
 <h3>Live Preview</h3>
-Changes to documents are updated in the preview window in real time.
 
 ####
 
@@ -41,8 +54,17 @@ Changes to documents are updated in the preview window in real time.
 
 ####
 
+<h3>Reformat files</h3>
+
+####
+
+<p align="center">
+  <img alt="Reformat File" src="./assets/reformat-file.gif" width="800" />
+</p>
+
+####
+
 <h3>Jump to Definition from Preview</h3>
-Click on a part of the preview document to jump to the definition of that element in the file.
 
 ####
 
@@ -53,7 +75,6 @@ Click on a part of the preview document to jump to the definition of that elemen
 ####
 
 <h3>Documentation on Hover</h3>
-Hover over a symbol to view its documentation.
 
 ####
 
@@ -64,7 +85,6 @@ Hover over a symbol to view its documentation.
 ####
 
 <h3>Find Usages</h3>
-List all the places a symbol is used in the project.
 
 ####
 
@@ -75,23 +95,11 @@ List all the places a symbol is used in the project.
 ####
 
 <h3>Autocomplete</h3>
-Suggestions for symbols as you type.
 
 ####
 
 <p align="center">
   <img alt="Reformat File" src="./assets/autocomplete.gif" width="800" />
-</p>
-
-####
-
-<h3>Reformat files</h3>
-Reformat entire files with `typstfmt` or `typstyle`.
-
-####
-
-<p align="center">
-  <img alt="Reformat File" src="./assets/reformat-file.gif" width="800" />
 </p>
 
 ####
@@ -115,7 +123,11 @@ Specify your local version of `tinymist` to be used with this plugin.
 
 ## Compatible IDEs
 
-Works in 2025.1+ IntelliJ IDEs.
+Works in 2025.1+ IntelliJ IDEs. May not work in Rider.
+
+## Compatible Tinymist
+
+Currently, only `tinymist` versions `0.13.14` and above are supported. 
 
 ## Feature Support
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.github.garetht.typstsupport
 pluginName=typst-support
 pluginRepositoryUrl=https://github.com/garetht/typst-support
 # SemVer format -> https://semver.org
-pluginVersion=0.0.3
+pluginVersion=0.0.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=251

--- a/src/main/kotlin/com/github/garetht/typstsupport/configuration/DefaultExecutionValidator.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/configuration/DefaultExecutionValidator.kt
@@ -24,8 +24,12 @@ class DefaultExecutionValidator(
       if (result.exitCode == 0) {
         val output = result.stdout.trim()
         val version = Version.Companion.parseVersion(output)
-        if (version != null) {
+        if (version == null) {
+          ExecutionValidation.Failed("No version information could be found.")
+        } else if (version >= VersionRequirement.version) {
           ExecutionValidation.Success(version)
+        } else if (version < VersionRequirement.version) {
+          ExecutionValidation.Failed("Tinymist version ${version.toPathString()} is below required version ${VersionRequirement.version.toPathString()}")
         } else {
           ExecutionValidation.Failed("Invalid binary output format")
         }

--- a/src/main/kotlin/com/github/garetht/typstsupport/configuration/SettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/configuration/SettingsConfigurable.kt
@@ -55,7 +55,7 @@ class SettingsConfigurable(
         buttonsGroup("Binary filepath") {
           row {
             automaticRadioButton = radioButton(
-              "Use automatically downloaded binary (v0.13.14)",
+              "Use automatically downloaded binary (${VersionRequirement.version.toPathString()})",
               BinarySource.USE_AUTOMATIC_DOWNLOAD
             )
           }

--- a/src/main/kotlin/com/github/garetht/typstsupport/configuration/SettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/configuration/SettingsConfigurable.kt
@@ -55,7 +55,7 @@ class SettingsConfigurable(
         buttonsGroup("Binary filepath") {
           row {
             automaticRadioButton = radioButton(
-              "Use automatically downloaded binary",
+              "Use automatically downloaded binary (v0.13.14)",
               BinarySource.USE_AUTOMATIC_DOWNLOAD
             )
           }

--- a/src/main/kotlin/com/github/garetht/typstsupport/configuration/VersionRequirement.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/configuration/VersionRequirement.kt
@@ -1,0 +1,7 @@
+package com.github.garetht.typstsupport.configuration
+
+import com.github.garetht.typstsupport.languageserver.locations.Version
+
+object VersionRequirement {
+  val version = Version(0, 13, 14)
+}

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/locations/TinymistLocationResolver.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/locations/TinymistLocationResolver.kt
@@ -12,7 +12,7 @@ import java.net.URI
 import java.nio.file.Path
 
 private const val TYPST_SUPPORT_ID = "com.github.garetht.typstsupport"
-private val version = Version(0, 13, 12)
+private val version = Version(0, 13, 14)
 
 class TinymistLocationResolver : LocationResolver {
   private val jnaNoClassPathKey = "jna.noclasspath"

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/locations/TinymistLocationResolver.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/locations/TinymistLocationResolver.kt
@@ -4,6 +4,7 @@ import com.github.garetht.typstsupport.configuration.BinarySource
 import com.github.garetht.typstsupport.configuration.DefaultPathValidator
 import com.github.garetht.typstsupport.configuration.PathValidation
 import com.github.garetht.typstsupport.configuration.SettingsState
+import com.github.garetht.typstsupport.configuration.VersionRequirement
 import com.github.garetht.typstsupport.notifier.Notifier
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.extensions.PluginId
@@ -12,8 +13,6 @@ import java.net.URI
 import java.nio.file.Path
 
 private const val TYPST_SUPPORT_ID = "com.github.garetht.typstsupport"
-private val version = Version(0, 13, 14)
-
 class TinymistLocationResolver : LocationResolver {
   private val jnaNoClassPathKey = "jna.noclasspath"
   private var jnaNoClassPath: String? = null
@@ -21,7 +20,7 @@ class TinymistLocationResolver : LocationResolver {
 
   private val binary =
     TinymistBinary(
-      version = version,
+      version = VersionRequirement.version,
       osName = OsName.fromString(System.getProperty("os.name")),
       osArchitecture = OsArchitecture.fromString(System.getProperty("os.arch")),
     )

--- a/src/main/kotlin/com/github/garetht/typstsupport/languageserver/locations/Version.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/languageserver/locations/Version.kt
@@ -2,7 +2,10 @@ package com.github.garetht.typstsupport.languageserver.locations
 
 import java.util.regex.Pattern
 
-data class Version(val major: Int, val minor: Int, val patch: Int) {
+data class Version(val major: Int, val minor: Int, val patch: Int): Comparable<Version> {
+  override fun compareTo(other: Version): Int =
+    compareValuesBy(this, other, { it.major }, { it.minor }, { it.patch })
+
   fun toPathString(): String {
     return "v$major.$minor.$patch"
   }

--- a/src/test/kotlin/com/github/garetht/typstsupport/configuration/DefaultExecutionValidatorTest.kt
+++ b/src/test/kotlin/com/github/garetht/typstsupport/configuration/DefaultExecutionValidatorTest.kt
@@ -29,8 +29,8 @@ class DefaultExecutionValidatorTest {
   fun `should return success with valid version output`() {
     // Given
     val binaryPath = "/path/to/binary"
-    val versionOutput = "tinymist 1.2.3"
-    val expectedVersion = Version(1, 2, 3)
+    val versionOutput = "tinymist 401.293.193"
+    val expectedVersion = Version(401, 293, 193)
 
     every { pathValidator.validateBinaryFile(binaryPath) } returns PathValidation.Success
     every { processExecutor.executeProcess(any()) } returns ProcessOutput(versionOutput, "", 0, false, false)
@@ -90,7 +90,7 @@ class DefaultExecutionValidatorTest {
 
     // Then
     assertInstanceOf(ExecutionValidation.Failed::class.java, result)
-    assertEquals("Invalid binary output format", (result as ExecutionValidation.Failed).message)
+    assertEquals("No version information could be found.", (result as ExecutionValidation.Failed).message)
   }
 
   @ParameterizedTest
@@ -140,7 +140,7 @@ class DefaultExecutionValidatorTest {
   fun `should verify command line is created with correct parameters`() {
     // Given
     val binaryPath = "/path/to/binary"
-    val versionOutput = "tinymist 1.2.3"
+    val versionOutput = "tinymist 401.293.193"
     var capturedCommandLine: GeneralCommandLine? = null
 
     every { pathValidator.validateBinaryFile(binaryPath) } returns PathValidation.Success
@@ -155,5 +155,22 @@ class DefaultExecutionValidatorTest {
     // Then
     assertEquals(binaryPath, capturedCommandLine?.exePath)
     assertEquals(listOf("-V"), capturedCommandLine?.parametersList?.list)
+  }
+
+  @Test
+  fun `should reject a binary version that is too low`() {
+    // Given
+    val binaryPath = "/path/to/binary"
+    val versionOutput = "tinymist 0.11.12"
+    val expectedVersion = Version(1, 2, 3)
+
+    every { pathValidator.validateBinaryFile(binaryPath) } returns PathValidation.Success
+    every { processExecutor.executeProcess(any()) } returns ProcessOutput(versionOutput, "", 0, false, false)
+
+    // When
+    val result = validator.validateBinaryExecution(binaryPath)
+
+    // Then
+    assertInstanceOf(ExecutionValidation.Failed::class.java, result)
   }
 } 

--- a/src/test/kotlin/com/github/garetht/typstsupport/languageserver/locations/TinymistLocationResolverTest.kt
+++ b/src/test/kotlin/com/github/garetht/typstsupport/languageserver/locations/TinymistLocationResolverTest.kt
@@ -165,7 +165,7 @@ class TinymistLocationResolverTest {
     )
 
     private val supportedVersions = listOf(
-      "0.13.12",
+      "0.13.14",
     )
 
     @JvmStatic
@@ -224,7 +224,7 @@ class TinymistLocationResolverTest {
             val basePath = "/%s".format(UUID.randomUUID().toString())
             val expectedPath = "%s/language-server/%s/tinymist%s".format(
               basePath,
-              "v0.13.12",
+              "v0.13.14",
               osOpt.executableExtension
             )
             yield(

--- a/src/test/kotlin/com/github/garetht/typstsupport/languageserver/locations/VersionTest.kt
+++ b/src/test/kotlin/com/github/garetht/typstsupport/languageserver/locations/VersionTest.kt
@@ -1,10 +1,16 @@
 package com.github.garetht.typstsupport.languageserver.locations
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 class VersionTest {
   @Test
@@ -26,6 +32,7 @@ class VersionTest {
     val version = Version(1, 2, 3)
     assertEquals("tinymist v1.2.3", version.toConsoleString())
   }
+
 
   @Test
   fun `test parseVersion with valid input`() {
@@ -79,5 +86,127 @@ class VersionTest {
 
     assertEquals(version1, version2)
     assertNotEquals(version1, version3)
+  }
+
+  @ParameterizedTest(name = "{0} should be less than {1}")
+  @MethodSource("provideLessThanVersions")
+  fun `test version less than`(version1: Version, version2: Version) {
+    assertTrue(version1 < version2)
+    assertTrue(version1.compareTo(version2) < 0)
+  }
+
+  @ParameterizedTest(name = "{0} should be greater than {1}")
+  @MethodSource("provideGreaterThanVersions")
+  fun `test version greater than`(version1: Version, version2: Version) {
+    assertTrue(version1 > version2)
+    assertTrue(version1.compareTo(version2) > 0)
+  }
+
+  @ParameterizedTest(name = "{0} should equal {1}")
+  @MethodSource("provideEqualVersions")
+  fun `test version equality`(version1: Version, version2: Version) {
+    assertEquals(0, version1.compareTo(version2))
+    assertTrue(version1 == version2)
+    assertFalse(version1 < version2)
+    assertFalse(version1 > version2)
+  }
+
+  @ParameterizedTest(name = "sorted({0}) should equal {1}")
+  @MethodSource("provideSortingTestCases")
+  fun `test version sorting`(versions: List<Version>, expected: List<Version>) {
+    assertEquals(expected, versions.sorted())
+  }
+
+  companion object {
+    @JvmStatic
+    fun provideLessThanVersions() = listOf(
+      // Major version differences
+      Arguments.of(Version(1, 0, 0), Version(2, 0, 0)),
+      Arguments.of(Version(1, 9, 9), Version(2, 0, 0)),
+
+      // Minor version differences (same major)
+      Arguments.of(Version(1, 1, 0), Version(1, 2, 0)),
+      Arguments.of(Version(1, 1, 9), Version(1, 2, 0)),
+
+      // Patch version differences (same major and minor)
+      Arguments.of(Version(1, 1, 1), Version(1, 1, 2)),
+      Arguments.of(Version(1, 1, 0), Version(1, 1, 1)),
+
+      // Mixed scenarios
+      Arguments.of(Version(0, 9, 9), Version(1, 0, 0)),
+      Arguments.of(Version(1, 0, 9), Version(1, 1, 0)),
+      Arguments.of(Version(2, 1, 1), Version(2, 1, 2))
+    )
+
+    @JvmStatic
+    fun provideGreaterThanVersions() = listOf(
+      // Major version differences
+      Arguments.of(Version(2, 0, 0), Version(1, 0, 0)),
+      Arguments.of(Version(2, 0, 0), Version(1, 9, 9)),
+
+      // Minor version differences (same major)
+      Arguments.of(Version(1, 2, 0), Version(1, 1, 0)),
+      Arguments.of(Version(1, 2, 0), Version(1, 1, 9)),
+
+      // Patch version differences (same major and minor)
+      Arguments.of(Version(1, 1, 2), Version(1, 1, 1)),
+      Arguments.of(Version(1, 1, 1), Version(1, 1, 0)),
+
+      // Mixed scenarios
+      Arguments.of(Version(1, 0, 0), Version(0, 9, 9)),
+      Arguments.of(Version(1, 1, 0), Version(1, 0, 9)),
+      Arguments.of(Version(2, 1, 2), Version(2, 1, 1))
+    )
+
+    @JvmStatic
+    fun provideEqualVersions() = listOf(
+      Arguments.of(Version(1, 0, 0), Version(1, 0, 0)),
+      Arguments.of(Version(1, 2, 3), Version(1, 2, 3)),
+      Arguments.of(Version(0, 0, 0), Version(0, 0, 0)),
+      Arguments.of(Version(10, 20, 30), Version(10, 20, 30))
+    )
+
+    @JvmStatic
+    fun provideSortingTestCases(): Stream<Arguments> = Stream.of(
+      // Simple case
+      Arguments.of(
+        listOf(Version(2, 0, 0), Version(1, 0, 0)),
+        listOf(Version(1, 0, 0), Version(2, 0, 0))
+      ),
+
+      // Complex case with all version components
+      Arguments.of(
+        listOf(
+          Version(2, 1, 0),
+          Version(1, 2, 3),
+          Version(2, 0, 1),
+          Version(1, 2, 2),
+          Version(1, 1, 0)
+        ),
+        listOf(
+          Version(1, 1, 0),
+          Version(1, 2, 2),
+          Version(1, 2, 3),
+          Version(2, 0, 1),
+          Version(2, 1, 0)
+        )
+      ),
+
+      // Edge case with zeros
+      Arguments.of(
+        listOf(
+          Version(1, 0, 1),
+          Version(0, 1, 0),
+          Version(0, 0, 1),
+          Version(1, 0, 0)
+        ),
+        listOf(
+          Version(0, 0, 1),
+          Version(0, 1, 0),
+          Version(1, 0, 0),
+          Version(1, 0, 1)
+        )
+      )
+    )
   }
 } 


### PR DESCRIPTION
Only `tinymist` versions 0.13.14 and above are supported now.